### PR TITLE
Fix generating unique component id

### DIFF
--- a/public/js/func.js
+++ b/public/js/func.js
@@ -137,7 +137,7 @@ var TIDYUPWHITE = new RegExp(String.fromCharCode(160), 'g');
 })();
 
 FUNC.makeid = function(type) {
-	return type + Date.now().toString(36);
+	return type + Date.now().toString(36).slice(4) + Math.random().toString(16).slice(10);
 };
 
 FUNC.trigger = function(el, data) {


### PR DESCRIPTION
`Date.now().toString(36)` - this fail to generate unique component id when asynchronously calling component install. I added additional randomness to id generation which fix the issue.  